### PR TITLE
Fix createdOn date format

### DIFF
--- a/datamodel/src/main/java/io/apicurio/tenantmanager/api/datamodel/ApicurioTenant.java
+++ b/datamodel/src/main/java/io/apicurio/tenantmanager/api/datamodel/ApicurioTenant.java
@@ -45,7 +45,7 @@ public class ApicurioTenant {
      * (Required)
      * 
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
     @JsonProperty("createdOn")
     @JsonPropertyDescription("Date when the tenant was created. ISO 8601 UTC timestamp.")
     private Date createdOn;


### PR DESCRIPTION
Align with the current implementation:
https://github.com/Apicurio/apicurio-registry/blob/440d91f385540b8555cb90878f77a4a9b7a2b195/multitenancy/tenant-manager-datamodel/src/main/java/io/apicurio/multitenant/api/datamodel/RegistryTenant.java#L48

Attempt to fix this test failure:
https://github.com/Apicurio/apicurio-registry/actions/runs/3112773815/jobs/5047030168#step:21:67

```
io.apicurio.registry.rest.client.exception.RestClientException: 
com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `java.util.Date` from String "2022-09-23T13:33:46Z": expected format "yyyy-MM-dd'T'HH:mm:ssZ"
 at [Source: (jdk.internal.net.http.ResponseSubscribers$HttpResponseInputStream); line: 1, column: 64] (through reference chain: io.apicurio.multitenant.api.datamodel.RegistryTenant["createdOn"])
```